### PR TITLE
BUILD must be a submethod

### DIFF
--- a/lib/GDBM.pm
+++ b/lib/GDBM.pm
@@ -278,7 +278,7 @@ class GDBM does Associative {
         self.new(:$filename);
     }
 
-    multi method BUILD(:$!filename!, |c) {
+    multi submethod BUILD(:$!filename!, |c) {
         $!file = File.new(file => $!filename, |c);
     }
 


### PR DESCRIPTION
My last fix for submethod handling in Rakudo breaks the module because
Rakudo error allowed to declare both method and submethod of the same
name. It's an error now, BUILD has to be a submethod.